### PR TITLE
Fix: Build process unicode error (by forcing UTF-8 encoding in batch script)

### DIFF
--- a/builddeepspeed.py
+++ b/builddeepspeed.py
@@ -299,6 +299,9 @@ class DeepSpeedPatcher:
             build_script = os.path.join(self.install_dir_var.get(), "run_build.bat")
             with open(build_script, 'w') as f:
                 f.write('@echo off\n')
+                f.write('chcp 65001\n')  # Set command window code page to UTF-8
+                f.write('set PYTHONUTF8=1\n')  # Force Python to use UTF-8 for I/O
+                f.write('set PYTHONIOENCODING=utf-8\n')  # Ensure Python uses UTF-8 for its I/O encoding                
                 # Call vcvars64.bat explicitly for 64-bit environment
                 f.write(f'call "{vcvars_path}"\n')
                 # Set up environment variables


### PR DESCRIPTION
Hey Erew, thx a lot for providing us this tool. It works great.

Got an issue during the DeepSpeed build process where the build would fail with the following error:

```bash
[2025-04-09 13:42:30] apply_rotary_pos_emb.cu
[2025-04-09 13:42:31] Build process error: 'charmap' codec can't decode byte 0x81 in position 107: character maps to <undefined>
[2025-04-09 13:42:31] Error during build: Build failed
```

Turned out the error was caused by the Windows command prompt using a legacy code page that does not properly handle certain unicode characters (from localized german messages). 

**Fix:**  
Script generator modified to force the environment into using UTF‑8.
Added the following lines:

```python
f.write('chcp 65001\n')          # Set command prompt’s code page to UTF‑8 so that output uses UTF‑8 encoding and supports all Unicode characters.
f.write('set PYTHONUTF8=1\n')      # Force Python to treat input/output as UTF‑8, overriding its default encoding.
f.write('set PYTHONIOENCODING=utf-8\n')  # Ensure Python’s standard I/O uses UTF‑8, allowing it to correctly read and display the build output.
```

Let me know if there are any questions.